### PR TITLE
removed hard coded image sizes for figure setting in movie rendering …

### DIFF
--- a/trunk/IO/trkRenderFancy2.m
+++ b/trunk/IO/trkRenderFancy2.m
@@ -229,7 +229,8 @@ for t = 1:TMAX
     drawnow;
 
     
-    set(f, 'Position', [1937 262 696 520]);
+    [img_height img_width] = size(B);
+    set(f, 'Position', [1937 262 img_width img_height]);
 %     F = getframe(gcf);
 %     I = F.cdata;
     I = opengl_cdata(f);


### PR DESCRIPTION
Dear developers,

Thank you very much for your valuable software.
I tried to apply your neurite tracking script to a micrograph time series produced in our institute.
We realized that the movie rendering of neutite branches did not work. 

The reason was, that the figure size was hardcoded, thus fitting to your test datasets but not to our time series of different size in x and y.  I changed the code (see below), now it works for our data.

So I recommend to add these small changes to your master branch.

Best
Christoph

Christoph Möhl
Image and Data Analysis Core Facility
DZNE Bonn/Germany